### PR TITLE
Fix: 누락된 큐레이션 정보 조회 관련 레포지토리 메서드 추가 

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationSpaceRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationSpaceRepository.java
@@ -13,6 +13,8 @@ import com.localmood.domain.curation.entity.CurationSpace;
 public interface CurationSpaceRepository extends JpaRepository<CurationSpace, Long> {
 	int countByCurationId(Long curationId);
 
+	List<CurationSpace> findByCurationId(Long curationId);
+
 	// Curation ID에 속한 Space ID 가져오기
 	@Query("SELECT cs.space.id FROM CurationSpace cs WHERE cs.curation.id = :curationId")
 	List<Long> findSpaceIdsByCurationId(@Param("curationId") Long curationId);

--- a/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
@@ -14,4 +14,8 @@ public interface ReviewImgRepository extends JpaRepository<ReviewImg, Long> {
 	// Space ID에 속한 이미지 최대 5개 가져오기
 	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id IN :spaceIds")
 	List<String> findTop5ImageUrlsBySpaceIds(@Param("spaceIds") List<Long> spaceIds);
+
+	// Space ID에 속한 모든 이미지 가져오기
+	@Query("SELECT new java.lang.String(ri.imgUrl) FROM ReviewImg ri WHERE ri.space.id = :spaceId")
+	List<String> findImageUrlsBySpaceId(@Param("spaceId") Long spaceId);
 }


### PR DESCRIPTION
# Summary
- 큐레이션 공간을 가져오는 findByCurationId 추가
- 공간의 이미지를 모두 가져오는 findImageUrlsBySpaceId 추가 

## To-do
- [x] findByCurationId 추가
- [x] findImageUrlsBySpaceId 추가 

## Related Issues
- Resolves #24 
