### PR TITLE
Feat: 사용자별 큐레이션 목록 조회 api 응답 형식 변환

### DIFF
--- a/localmood-api/src/main/java/com/localmood/curation/controller/CurationController.java
+++ b/localmood-api/src/main/java/com/localmood/curation/controller/CurationController.java
@@ -1,6 +1,7 @@
 package com.localmood.curation.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -86,7 +87,7 @@ public class CurationController {
 
 	@Operation(summary = "사용자별 큐레이션 목록 조회 API", description = "사용자별 큐레이션 목록을 조회합니다.")
 	@GetMapping("/member/{id}")
-	public List<CurationResponseDto> getCurationsForMember(@PathVariable("id") Long memberId) {
+	public Map<String, Object> getCurationsForMember(@PathVariable("id") Long memberId) {
 		return curationService.getCurationsForMember(memberId);
 	}
 

--- a/localmood-api/src/main/java/com/localmood/curation/response/CurationResponseDto.java
+++ b/localmood-api/src/main/java/com/localmood/curation/response/CurationResponseDto.java
@@ -1,6 +1,8 @@
 package com.localmood.curation.response;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,18 +11,31 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CurationResponseDto {
 
+	private Long id;
 	private String author;
 	private List<String> image;
 	private String title;
 	private int spaceCount;
 	private List<String> keyword;
 
-	public CurationResponseDto(String authorName, List<String> image, String title, int spaceCount,
+	public CurationResponseDto(Long id, String authorName, List<String> image, String title, int spaceCount,
 		List<String> keyword) {
+		this.id = id;
 		this.author = authorName;
 		this.image = image;
 		this.title = title;
 		this.spaceCount = spaceCount;
 		this.keyword = keyword;
+	}
+
+	public Map<String, Object> toMap() {
+		Map<String, Object> map = new HashMap<>();
+		map.put("id", this.id);
+		map.put("author", this.author);
+		map.put("image", this.image);
+		map.put("title", this.title);
+		map.put("spaceCount", this.spaceCount);
+		map.put("keyword", this.keyword);
+		return map;
 	}
 }

--- a/localmood-api/src/main/java/com/localmood/curation/service/CurationService.java
+++ b/localmood-api/src/main/java/com/localmood/curation/service/CurationService.java
@@ -3,7 +3,9 @@ package com.localmood.curation.service;
 import static com.localmood.common.utils.RepositoryUtil.*;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -92,7 +94,7 @@ public class CurationService {
 		List<String> image = getCurationImg(curation.getId());
 
 		return new CurationResponseDto(
-			authorName, image, curation.getTitle(),
+			curation.getId(), authorName, image, curation.getTitle(),
 			curationSpaceRepository.countByCurationId(curation.getId()),
 			Arrays.asList(curation.getKeyword().split(","))
 		);
@@ -121,14 +123,22 @@ public class CurationService {
 		curationSpaceRepository.save(curationSpace);
 	}
 
-	public List<CurationResponseDto> getCurationsForMember(Long memberId) {
-		// 최신순으로 정렬한 curation 가져오기
-		List<Curation> curation = curationRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+	public Map<String, Object> getCurationsForMember(Long memberId) {
+		Map<String, Object> response = new LinkedHashMap<>();
 
-		return curation
+		// 최신순으로 정렬한 curation 가져오기
+		List<Curation> curations = curationRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+		List<Map<String, Object>> curationList = curations
 			.stream()
 			.map(this::mapToCurationResponseDto)
+			.map(CurationResponseDto::toMap)
 			.collect(Collectors.toList());
+
+		response.put("curationCount", curationList.size());
+		response.put("curation", curationList);
+
+		return response;
 	}
 
 	public CurationDetailResponseDto getCurationDetail(String curationId) {


### PR DESCRIPTION
# Summary
사용자별 공간 기록 조회 API 응답에 필드를 추가하고 형식을 Map으로 변환했습니다.
-  Dto에 큐레이션 ID 필드를 추가하였습니다.
-  Map으로의 변환에 따라 기존 Service 메서드를 업데이트하고 Dto에 toMap() 메서드를 추가하였습니다. 

## To-do
- [x] CurationResponseDto 업데이트
- [x] Controller에서 응답 형식 변환
- [x] Service에서 응답 로직 변환 

## Related Issues
- Resolves #24 
