### PR TITLE
Hotfix: 공간 상세조회 API 큐레이션 정보 쿼리 오류 수정

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -4,7 +4,6 @@ import static com.localmood.domain.curation.entity.QCuration.*;
 import static com.localmood.domain.curation.entity.QCurationSpace.*;
 import static com.localmood.domain.scrap.entity.QScrapSpace.*;
 import static com.localmood.domain.space.entity.QSpaceInfo.*;
-import static com.querydsl.core.types.ExpressionUtils.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,6 +12,8 @@ import com.localmood.common.util.ScrapUtil;
 import com.localmood.domain.member.dto.MemberScrapCurationDto;
 import com.localmood.domain.member.dto.QMemberScrapCurationDto;
 import com.localmood.domain.member.entity.Member;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,10 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 								curation.title,
 								curation.member.nickname,
 								curation.keyword,
-								count(curationSpace.id),
+								ExpressionUtils.as
+										(JPAExpressions.select(curationSpace.space.id.countDistinct())
+										.from(curationSpace)
+										.where(curationSpace.curation.id.eq(curation.id)), "spaceCount"),
 								spaceInfo.thumbnailImgUrl,
 								scrapUtil.isScraped(member)
 						)


### PR DESCRIPTION
# Summary
공간 상세조회 API 내 큐레이션 장소 개수 반환 쿼리 오류 

## To-do
- [x]  CurationRepositoryImpl 쿼리 리팩토링

## Related Issues
- Resolves #250 
