### PR TITLE
Hotfix: 스크랩 목록 조회 API 공간 중복 오류

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/scrap/repository/ScrapSpaceRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/scrap/repository/ScrapSpaceRepositoryImpl.java
@@ -33,7 +33,7 @@ public class ScrapSpaceRepositoryImpl implements ScrapSpaceRepositoryCustom{
 		}
 
 		return queryFactory
-				.select(
+				.selectDistinct(
 						new QMemberScrapSpaceDto(
 								space.id,
 								space.name,


### PR DESCRIPTION
# Summary
멤버별 스크랩 공간 목록 조회 시 동일 공간이 중복으로 오는 오류

## To-do
- [x] 쿼리 리팩토링

## Related Issues
- Resolves #265 
