### PR TITLE
Feat: 큐레이션 공개 상태 전환 API 

### DIFF
--- a/localmood-api/src/main/java/com/localmood/api/curation/controller/CurationController.java
+++ b/localmood-api/src/main/java/com/localmood/api/curation/controller/CurationController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import com.localmood.domain.curation.dto.response.CurationPrivacyResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -134,6 +135,16 @@ public class CurationController {
 		@CurrentUser Member member
 	) {
 		var res = curationService.getCurationFilterList(request, Optional.ofNullable(member));
+		return SuccessResponse.ok(res);
+	}
+
+	@Operation(summary = "큐레이션 공개 상태 변경 API", description = "사용자의 큐레이션 공개 상태를 변경합니다.")
+	@GetMapping("/{curationId}/privacy")
+	public ResponseEntity<CurationPrivacyResponseDto> updateCurationPrivacy(
+			@PathVariable("curationId") String curationId,
+			@CurrentUser Member member
+	) {
+		var res = curationService.updateCurationPrivacy(curationId, member.getId());
 		return SuccessResponse.ok(res);
 	}
 

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/entity/Curation.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/entity/Curation.java
@@ -40,6 +40,10 @@ public class Curation extends BaseTimeEntity {
 	@Column
 	private Boolean privacy;
 
+	public void setPrivacy(boolean privacy) {
+		this.privacy = privacy;
+	}
+
 	@Builder
 	public Curation (Member member, String title, String keyword, Boolean privacy) {
 		this.member = member;

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/service/CurationService.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/service/CurationService.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.localmood.common.util.CheckScrapUtil;
+import com.localmood.domain.curation.dto.response.CurationPrivacyResponseDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,8 +28,6 @@ import com.localmood.domain.curation.repository.CurationSpaceRepository;
 import com.localmood.domain.member.entity.Member;
 import com.localmood.domain.member.repository.MemberRepository;
 import com.localmood.domain.review.repository.ReviewImgRepository;
-import com.localmood.domain.scrap.repository.ScrapCurationRepository;
-import com.localmood.domain.scrap.repository.ScrapSpaceRepository;
 import com.localmood.domain.space.entity.Space;
 import com.localmood.domain.space.entity.SpaceInfo;
 import com.localmood.domain.space.entity.SpaceMenu;
@@ -280,6 +279,19 @@ public class CurationService {
 
 		return response;
 	}
+
+	// 큐레이션 공개 상태 변경
+	public CurationPrivacyResponseDto updateCurationPrivacy(String curationId, Long memberId) {
+		Curation curation = curationRepository.findById(Long.parseLong(curationId))
+				.orElseThrow(() -> new LocalmoodException(ErrorCode.CURATION_NOT_FOUND));
+
+		boolean newPrivacy = curation.getPrivacy() == null || !curation.getPrivacy();
+		curation.setPrivacy(newPrivacy);
+		curationRepository.save(curation);
+
+		return new CurationPrivacyResponseDto(curation.getId(), newPrivacy, memberId);
+	}
+
 
 	private List<String> getImageUrls(Long spaceId) {
 		return reviewImgRepository.findImageUrlsBySpaceId(spaceId);


### PR DESCRIPTION
# Summary
큐레이션의 공개 상태를 변경하는 API 생성

## To-do
- [x] controller 매핑
- [x] service 메서드 추가
- [x] entity 수정

## Related Issues
- Resolves #267 
