### PR TITLE
Refactor: 공간기록 중복 작성 방지 API 리팩토링 (조회 관련 API)

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/member/dto/MemberScrapSpaceDto.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/member/dto/MemberScrapSpaceDto.java
@@ -9,15 +9,17 @@ public record MemberScrapSpaceDto(
 		SpaceType type,
 		String address,
 		String imgUrl,
-		Boolean isScraped
+		Boolean isScraped,
+		Boolean isReviewed
 ){
 	@QueryProjection
-	public MemberScrapSpaceDto(Long id, String name, SpaceType type, String address, String imgUrl, Boolean isScraped){
+	public MemberScrapSpaceDto(Long id, String name, SpaceType type, String address, String imgUrl, Boolean isScraped, Boolean isReviewed){
 		this.id = id;
 		this.name = name;
 		this.type = type;
 		this.address = address;
 		this.imgUrl = imgUrl;
 		this.isScraped = isScraped;
+		this.isReviewed = isReviewed;
 	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewRepository.java
@@ -14,4 +14,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	List<Review> findBySpaceId(Long spaceId);
 
+    boolean existsByMemberIdAndSpaceId(Long memberId, Long spaceId);
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/scrap/repository/ScrapSpaceRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/scrap/repository/ScrapSpaceRepositoryImpl.java
@@ -4,13 +4,15 @@ import static com.localmood.domain.curation.entity.QCuration.*;
 import static com.localmood.domain.curation.entity.QCurationSpace.*;
 import static com.localmood.domain.space.entity.QSpace.*;
 import static com.localmood.domain.space.entity.QSpaceInfo.*;
-import static com.querydsl.core.types.dsl.Expressions.*;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import com.localmood.domain.member.dto.QMemberScrapSpaceDto;
 import com.localmood.domain.member.dto.MemberScrapSpaceDto;
+import com.localmood.domain.review.repository.ReviewRepository;
+import com.localmood.domain.space.entity.SpaceType;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class ScrapSpaceRepositoryImpl implements ScrapSpaceRepositoryCustom{
 
 	private final JPAQueryFactory queryFactory;
+	private final ReviewRepository reviewRepository;
 
 	@Override
 	public List<MemberScrapSpaceDto> findMemberScrapSpaceByMemberId(Long memberId) {
@@ -32,16 +35,13 @@ public class ScrapSpaceRepositoryImpl implements ScrapSpaceRepositoryCustom{
 			return Collections.emptyList();
 		}
 
-		return queryFactory
-				.selectDistinct(
-						new QMemberScrapSpaceDto(
-								space.id,
-								space.name,
-								space.type,
-								space.address,
-								spaceInfo.thumbnailImgUrl,
-								TRUE
-						)
+		List<Tuple> queryResult = queryFactory
+				.select(
+						space.id,
+						space.name,
+						space.type,
+						space.address,
+						spaceInfo.thumbnailImgUrl
 				)
 				.from(space)
 				.leftJoin(spaceInfo)
@@ -50,7 +50,19 @@ public class ScrapSpaceRepositoryImpl implements ScrapSpaceRepositoryCustom{
 				.on(space.id.eq(curationSpace.space.id))
 				.where(curationSpace.curation.id.in(curationIds))
 				.orderBy(curationSpace.modifiedAt.desc())
+				.distinct()
 				.fetch();
+
+		return queryResult.stream().map(tuple -> {
+			Long id = tuple.get(space.id);
+			String name = tuple.get(space.name);
+			SpaceType type = tuple.get(space.type);
+			String address = tuple.get(space.address);
+			String thumbnailImgUrl = tuple.get(spaceInfo.thumbnailImgUrl);
+			boolean isReviewed = reviewRepository.existsByMemberIdAndSpaceId(memberId, id);
+
+			return new MemberScrapSpaceDto(id, name, type, address, thumbnailImgUrl, true, isReviewed);
+		}).collect(Collectors.toList());
 	}
 
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
@@ -15,6 +15,7 @@ import com.localmood.common.util.CheckScrapUtil;
 import com.localmood.common.util.ScrapUtil;
 import com.localmood.domain.member.dto.MemberScrapSpaceDto;
 import com.localmood.domain.member.entity.Member;
+import com.localmood.domain.review.repository.ReviewRepository;
 import com.localmood.domain.space.dto.SpaceSearchDto;
 import com.localmood.domain.space.dto.SpaceRecommendDto;
 import com.localmood.domain.space.entity.SpaceDish;
@@ -34,8 +35,8 @@ import lombok.RequiredArgsConstructor;
 public class SpaceRepositoryImpl implements SpaceRepositoryCustom{
 
 	private final JPAQueryFactory queryFactory;
-	private final ScrapUtil scrapUtil;
 	private final CheckScrapUtil checkScrapUtil;
+	private final ReviewRepository reviewRepository;
 
 	@Override
 	public List<SpaceRecommendDto> findRestaurantRecommendByKeyword(String keyword, Optional<Member> member) {
@@ -294,8 +295,9 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom{
 			String address = tuple.get(space.address);
 			String thumbnailImgUrl = tuple.get(spaceInfo.thumbnailImgUrl);
 			boolean isScraped = member.map(currMember -> checkScrapUtil.checkIfSpaceScraped(id, currMember.getId())).orElse(false);
+			boolean isReviewed = reviewRepository.existsByMemberIdAndSpaceId(member.get().getId(), id);
 
-			return new MemberScrapSpaceDto(id, name, type, address, thumbnailImgUrl, isScraped);
+			return new MemberScrapSpaceDto(id, name, type, address, thumbnailImgUrl, isScraped, isReviewed);
 		}).collect(Collectors.toList());
 	}
 


### PR DESCRIPTION
# Summary
공간기록 중복 작성을 방지하기 위하여
장소 관련 API 응답에 공간기록 작성 여부 반환

## To-do
- [x] dto 리팩토링
- [x] 공간 상세 조회 API 리팩토링
- [x] 멤버별 스크랩 장소 목록 조회 API 리팩토링

## Related Issues
- Resolves #273 
