### PR TITLE
Refactor: 공간기록 중복 작성 방지 리팩토링 (검색 관련 API)

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/space/dto/SpaceSearchDto.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/dto/SpaceSearchDto.java
@@ -22,11 +22,12 @@ public class SpaceSearchDto {
 	private List<String> keyword;
 	private String imgUrl;
 	private Boolean isScraped;
+	private Boolean isReviewed;
 	private Long scrapCount;
 	private LocalDateTime modifiedAt;
 
 	@QueryProjection
-	public SpaceSearchDto(Long id, String name, SpaceType type, String address, String purpose, String keyword, String imgUrl, Boolean isScraped, Long scrapCount, LocalDateTime modifiedAt){
+	public SpaceSearchDto(Long id, String name, SpaceType type, String address, String purpose, String keyword, String imgUrl, Boolean isScraped, Boolean isReviewed, Long scrapCount, LocalDateTime modifiedAt){
 		this.id = id;
 		this.name = name;
 		this.type = type;
@@ -35,6 +36,7 @@ public class SpaceSearchDto {
 		this.keyword = ArrayUtil.toArr(keyword);
 		this.imgUrl = imgUrl;
 		this.isScraped = isScraped;
+		this.isReviewed = isReviewed;
 		this.scrapCount = scrapCount;
 		this.modifiedAt = modifiedAt;
 	}

--- a/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
@@ -175,8 +175,9 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom{
 			LocalDateTime modifiedAt = tuple.get(spaceInfo.modifiedAt);
 
 			boolean isScraped = member.map(currMember -> checkScrapUtil.checkIfSpaceScraped(id, currMember.getId())).orElse(false);
+			boolean isReviewed = reviewRepository.existsByMemberIdAndSpaceId(member.get().getId(), id);
 
-			return new SpaceSearchDto(id, spaceName, type, address, purpose, interior, thumbnailImgUrl, isScraped, scrapCount, modifiedAt);
+			return new SpaceSearchDto(id, spaceName, type, address, purpose, interior, thumbnailImgUrl, isScraped, isReviewed, scrapCount, modifiedAt);
 		}).collect(Collectors.toList());
 
 		return spaceList;
@@ -262,8 +263,9 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom{
 			LocalDateTime modifiedAt = tuple.get(spaceInfo.modifiedAt);
 
 			boolean isScraped = member.map(currMember -> checkScrapUtil.checkIfSpaceScraped(id, currMember.getId())).orElse(false);
+			boolean isReviewed = reviewRepository.existsByMemberIdAndSpaceId(member.get().getId(), id);
 
-			return new SpaceSearchDto(id, spaceName, spaceType, address, spacePurpose, spaceInterior, thumbnailImgUrl, isScraped, scrapCount, modifiedAt);
+			return new SpaceSearchDto(id, spaceName, spaceType, address, spacePurpose, spaceInterior, thumbnailImgUrl, isScraped, isReviewed, scrapCount, modifiedAt);
 		}).collect(Collectors.toList());
 
 		return spaceList;


### PR DESCRIPTION
# Summary
공간기록 중복 작성을 방지하기 위하여
장소 검색 관련 API 응답에 공간기록 작성 여부 반환

## To-do
- [x] dto 리팩토링
- [x] 장소명 검색 API 리팩토링
- [x] 장소 키워드 검색 API 리팩토링

## Related Issues
- Resolves #273 
