### PR TITLE
Hotfix: 공간 상세 조회 API 큐레이션 관련 쿼리 수정

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -48,7 +48,8 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.on(curationSpace.space.id.eq(spaceInfo.space.id))
 				.leftJoin(scrapSpace)
 				.on(curationSpace.space.id.eq(scrapSpace.space.id))
-				.where(curationSpace.space.id.eq(spaceId))
+				.where(curationSpace.space.id.eq(spaceId)
+						.and(curation.privacy.isTrue().not()))
 				.groupBy(curation.id)
 				.distinct()
 				.fetch();


### PR DESCRIPTION
# Summary
공간 상세 조회 API 내 공간이 담긴 큐레이션(relatedCurationList)에서 
공개 여부를 판단하지 않고 모든 목록을 반환하고 있는 문제 

## To-do
- [x] findCurationBySpaceId 쿼리에 공개 여부 판단 부분 추가

## Related Issues
- Resolves #279 
