### PR TITLE
Hotfix: 공간 키워드 검색 API 오류 

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/repository/SpaceRepositoryImpl.java
@@ -213,7 +213,11 @@ public class SpaceRepositoryImpl implements SpaceRepositoryCustom{
 			builder.and(spaceInfo.optServ.contains(optServ));
 		}
 		if (!dish.equals("ALL")){
-			builder.and(spaceMenu.dish.eq(SpaceDish.of(dish)));
+			if (dish.equals("한식 전체")) {
+				builder.and(space.subType.eq(SpaceSubType.KOREAN));
+			} else {
+				builder.and(spaceMenu.dish.eq(SpaceDish.of(dish)));
+			}
 		}
 		if (!dishDesc.equals("ALL")) {
 			builder.and(spaceMenu.dishDesc.contains(dishDesc));


### PR DESCRIPTION
# Summary
공간 키워드 검색 API '한식 전체' 선택 시 오류 발생 문제 

## To-do
- [x] findSpaceByKeywords에 '한식 전체' 처리 쿼리 추가

## Related Issues
- Resolves #279
