### PR TITLE
Hotfix: 큐레이션 API 로직 리팩토링

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
@@ -11,12 +11,6 @@ import com.localmood.domain.curation.entity.Curation;
 @Repository
 public interface CurationRepository extends JpaRepository<Curation, Long>, CurationRepositoryCustom {
 
-	// 스크랩 수 내림차순으로 큐레이션 ID 리스트 검색
-	@Query(value =
-			"SELECT c.id FROM curation c JOIN scrap_curation sc ON c.id = sc.curation_id " +
-			"GROUP BY c.id ORDER BY COUNT(sc.id) DESC LIMIT 5", nativeQuery = true)
-	List<Long> findCurationsByScrapCount();
-
 	// 멤버가 작성한 큐레이션을 작성일 기준으로 내림차순으로 정렬해 검색
 	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
@@ -9,9 +9,5 @@ import com.localmood.domain.curation.entity.Curation;
 
 @Repository
 public interface CurationRepository extends JpaRepository<Curation, Long>, CurationRepositoryCustom {
-
-	// 멤버가 작성한 큐레이션을 작성일 기준으로 내림차순으로 정렬해 검색
-	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
-
 	List<Curation> findByMemberId(Long memberId);
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
@@ -14,9 +14,6 @@ public interface CurationRepository extends JpaRepository<Curation, Long>, Curat
 	// 멤버가 작성한 큐레이션을 작성일 기준으로 내림차순으로 정렬해 검색
 	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
-	// 제목으로 찾기
-	List<Curation> findByTitleContaining(String title);
-
 	// 키워드로 찾기
 	List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2);
 

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.localmood.domain.curation.entity.Curation;
 
@@ -13,9 +12,6 @@ public interface CurationRepository extends JpaRepository<Curation, Long>, Curat
 
 	// 멤버가 작성한 큐레이션을 작성일 기준으로 내림차순으로 정렬해 검색
 	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
-
-	// 키워드로 찾기
-	List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2);
 
 	List<Curation> findByMemberId(Long memberId);
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.localmood.domain.curation.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.localmood.domain.curation.entity.Curation;
 import com.localmood.domain.member.dto.MemberScrapCurationDto;
 import com.localmood.domain.member.entity.Member;
 
@@ -10,4 +11,6 @@ public interface CurationRepositoryCustom {
 	List<MemberScrapCurationDto> findCurationBySpaceId(Long spaceId, Optional<Member> member);
 
 	List<Long> findCurationsByScrapCount();
+
+	List<Curation> findByTitleContaining(String title);
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
@@ -15,4 +15,7 @@ public interface CurationRepositoryCustom {
 	List<Curation> findByTitleContaining(String title);
 
 	List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2);
+
+	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
@@ -10,12 +10,16 @@ import com.localmood.domain.member.entity.Member;
 public interface CurationRepositoryCustom {
 	List<MemberScrapCurationDto> findCurationBySpaceId(Long spaceId, Optional<Member> member);
 
+	// 추천 큐레이션 조회
 	List<Long> findCurationsByScrapCount();
 
+	// 제목으로 큐레이션 조회
 	List<Curation> findByTitleContaining(String title);
 
+	// 키워드로 큐레이션 조회
 	List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2);
 
+	// 멤버별 큐레이션 조회
 	List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId);
 
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
@@ -13,4 +13,6 @@ public interface CurationRepositoryCustom {
 	List<Long> findCurationsByScrapCount();
 
 	List<Curation> findByTitleContaining(String title);
+
+	List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2);
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryCustom.java
@@ -8,4 +8,6 @@ import com.localmood.domain.member.entity.Member;
 
 public interface CurationRepositoryCustom {
 	List<MemberScrapCurationDto> findCurationBySpaceId(Long spaceId, Optional<Member> member);
+
+	List<Long> findCurationsByScrapCount();
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -81,4 +81,16 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 					.and(curation.privacy.eq(false)))
 				.fetch();
 	}
+
+	@Override
+	public List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2) {
+		QCuration curation = QCuration.curation;
+
+		return queryFactory
+				.selectFrom(curation)
+				.where(curation.keyword.contains(keyword1)
+						.or(curation.keyword.contains(keyword2))
+						.and(curation.privacy.eq(false)))
+				.fetch();
+	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -93,4 +93,16 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 						.and(curation.privacy.eq(false)))
 				.fetch();
 	}
+
+	@Override
+	public List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId) {
+		QCuration curation = QCuration.curation;
+
+		return queryFactory
+				.selectFrom(curation)
+				.where(curation.member.id.eq(memberId)
+						.and(curation.privacy.eq(false)))
+				.orderBy(curation.createdAt.desc())
+				.fetch();
+	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.localmood.domain.curation.repository;
 
 import static com.localmood.domain.curation.entity.QCuration.*;
 import static com.localmood.domain.curation.entity.QCurationSpace.*;
+import static com.localmood.domain.scrap.entity.QScrapCuration.scrapCuration;
 import static com.localmood.domain.scrap.entity.QScrapSpace.*;
 import static com.localmood.domain.space.entity.QSpaceInfo.*;
 
@@ -52,6 +53,19 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 						.and(curation.privacy.isTrue().not()))
 				.groupBy(curation.id)
 				.distinct()
+				.fetch();
+	}
+
+	@Override
+	public List<Long> findCurationsByScrapCount() {
+		return queryFactory
+				.select(curation.id)
+				.from(curation)
+				.join(scrapCuration).on(curation.id.eq(scrapCuration.curation.id))
+				.where(curation.privacy.eq(false))
+				.groupBy(curation.id)
+				.orderBy(scrapCuration.id.count().desc())
+				.limit(5)
 				.fetch();
 	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -77,7 +77,8 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 
 		return queryFactory
 				.selectFrom(curation)
-				.where(curation.title.contains(title))
+				.where(curation.title.contains(title)
+					.and(curation.privacy.eq(false)))
 				.fetch();
 	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -58,6 +58,7 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.fetch();
 	}
 
+	// 추천 큐레이션 조회
 	@Override
 	public List<Long> findCurationsByScrapCount() {
 		return queryFactory
@@ -71,6 +72,7 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.fetch();
 	}
 
+	// 제목으로 큐레이션 조회
 	@Override
 	public List<Curation> findByTitleContaining(String title) {
 		QCuration curation = QCuration.curation;
@@ -82,6 +84,7 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.fetch();
 	}
 
+	// 키워드로 큐레이션 조회
 	@Override
 	public List<Curation> findByKeywordContainingOrKeywordContaining(String keyword1, String keyword2) {
 		QCuration curation = QCuration.curation;
@@ -94,6 +97,7 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.fetch();
 	}
 
+	// 멤버별 큐레이션 조회
 	@Override
 	public List<Curation> findByMemberIdOrderByCreatedAtDesc(Long memberId) {
 		QCuration curation = QCuration.curation;

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 import com.localmood.common.util.ScrapUtil;
+import com.localmood.domain.curation.entity.Curation;
+import com.localmood.domain.curation.entity.QCuration;
 import com.localmood.domain.member.dto.MemberScrapCurationDto;
 import com.localmood.domain.member.dto.QMemberScrapCurationDto;
 import com.localmood.domain.member.entity.Member;
@@ -66,6 +68,16 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 				.groupBy(curation.id)
 				.orderBy(scrapCuration.id.count().desc())
 				.limit(5)
+				.fetch();
+	}
+
+	@Override
+	public List<Curation> findByTitleContaining(String title) {
+		QCuration curation = QCuration.curation;
+
+		return queryFactory
+				.selectFrom(curation)
+				.where(curation.title.contains(title))
 				.fetch();
 	}
 }

--- a/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/repository/CurationRepositoryImpl.java
@@ -104,8 +104,7 @@ public class CurationRepositoryImpl implements CurationRepositoryCustom{
 
 		return queryFactory
 				.selectFrom(curation)
-				.where(curation.member.id.eq(memberId)
-						.and(curation.privacy.eq(false)))
+				.where(curation.member.id.eq(memberId))
 				.orderBy(curation.createdAt.desc())
 				.fetch();
 	}


### PR DESCRIPTION
# Summary
큐레이션 도메인 API의 **공개여부**에 따른 로직 수정 & Query DSL 리팩토링

## To-do
- [x] 추천 큐레이션 조회
- [x]  제목으로 큐레이션 목록 조회
- [x]  키워드로 큐레이션 목록 조회
- [x]  사용자별 큐레이션 스크랩 목록 조회

## Related Issues
- Resolves #283 
