### PR TITLE
Refactor: 공간 이미지 개수 limit 설정

### DIFF
--- a/localmood-domain/src/main/java/com/localmood/domain/curation/service/CurationService.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/curation/service/CurationService.java
@@ -118,7 +118,7 @@ public class CurationService {
 		List<Long> spaceIds = findSpaceIdsByCurationId(curationId);
 
 		// 공간 이미지 최대 5개 가져오기
-		return reviewImgRepository.findTop5ImageUrlsBySpaceIds(spaceIds)
+		return reviewImgRepository.findImageUrlsBySpaceIdsOrderByCreatedAtAsc(spaceIds)
 			.stream()
 			.limit(5)
 			.collect(Collectors.toList());
@@ -299,7 +299,10 @@ public class CurationService {
 
 
 	private List<String> getImageUrls(Long spaceId) {
-		return reviewImgRepository.findImageUrlsBySpaceId(spaceId);
+		return reviewImgRepository.findImageUrlsBySpaceIdOrderByCreatedAtAsc(spaceId)
+				.stream()
+				.limit(2)
+				.collect(Collectors.toList());
 	}
 
 	// TODO

--- a/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
@@ -12,13 +12,14 @@ import com.localmood.domain.review.entity.ReviewImg;
 
 @Repository
 public interface ReviewImgRepository extends JpaRepository<ReviewImg, Long> {
-	// Space ID에 속한 이미지 최대 5개 가져오기
+	@Query("SELECT new java.lang.String(ri.imgUrl) FROM ReviewImg ri WHERE ri.space.id = :spaceId")
+	List<String> findImageUrlsBySpaceId(@Param("spaceId") Long spaceId);
+
 	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id IN :spaceIds")
 	List<String> findTop5ImageUrlsBySpaceIds(@Param("spaceIds") List<Long> spaceIds);
 
-	// Space ID에 속한 모든 이미지 가져오기
-	@Query("SELECT new java.lang.String(ri.imgUrl) FROM ReviewImg ri WHERE ri.space.id = :spaceId")
-	List<String> findImageUrlsBySpaceId(@Param("spaceId") Long spaceId);
+	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id = :spaceId ORDER BY ri.createdAt ASC")
+	List<String> findImageUrlsBySpaceIdOrderByCreatedAtAsc(@Param("spaceId") Long spaceId);
 
 	Optional<ReviewImg> findByReviewId(Long reviewId);
 	List<ReviewImg> findListByReviewId(Long reviewId);

--- a/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/review/repository/ReviewImgRepository.java
@@ -12,11 +12,8 @@ import com.localmood.domain.review.entity.ReviewImg;
 
 @Repository
 public interface ReviewImgRepository extends JpaRepository<ReviewImg, Long> {
-	@Query("SELECT new java.lang.String(ri.imgUrl) FROM ReviewImg ri WHERE ri.space.id = :spaceId")
-	List<String> findImageUrlsBySpaceId(@Param("spaceId") Long spaceId);
-
-	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id IN :spaceIds")
-	List<String> findTop5ImageUrlsBySpaceIds(@Param("spaceIds") List<Long> spaceIds);
+	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id IN :spaceIds ORDER BY ri.createdAt ASC")
+	List<String> findImageUrlsBySpaceIdsOrderByCreatedAtAsc(@Param("spaceIds") List<Long> spaceIds);
 
 	@Query("SELECT ri.imgUrl FROM ReviewImg ri WHERE ri.space.id = :spaceId ORDER BY ri.createdAt ASC")
 	List<String> findImageUrlsBySpaceIdOrderByCreatedAtAsc(@Param("spaceId") Long spaceId);

--- a/localmood-domain/src/main/java/com/localmood/domain/space/service/SpaceService.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/service/SpaceService.java
@@ -98,7 +98,10 @@ public class SpaceService {
 		Space space = spaceRepository.findById(spaceId).orElseThrow();
 		SpaceInfo spaceInfo = spaceInfoRepository.findBySpaceId(spaceId).orElseThrow();
 		SpaceMenu spaceMenu = spaceMenuRepository.findBySpaceId(spaceId).orElseThrow();
-		List<String> imgUrlList = reviewImgRepository.findImageUrlsBySpaceId(spaceId);
+		List<String> imgUrlList = reviewImgRepository.findImageUrlsBySpaceIdOrderByCreatedAtAsc(spaceId)
+				.stream()
+				.limit(2)
+				.collect(Collectors.toList());
 		Boolean isScraped = member.isPresent() ? checkScrapUtil.checkIfSpaceScraped(spaceId, member.get().getId()) : false;
 		List<Review> reviews = reviewRepository.findBySpaceId(spaceId);
 


### PR DESCRIPTION
# Summary
공간 이미지 전송을 포함하는 API들에 대해 이미지 개수 limit 설정

## To-do
- [x] 쿼리 수정 
- [x] 큐레이션 상세 조회 API 적용 
- [x]  공간 상세 조회 API 적용


## Related Issues
- Resolves #290 
