### PR TITLE
Refactor: 공간별 공간기록 조회 API 정렬 기준 추가 

### DIFF
--- a/localmood-api/src/main/java/com/localmood/api/review/service/ReviewService.java
+++ b/localmood-api/src/main/java/com/localmood/api/review/service/ReviewService.java
@@ -175,6 +175,17 @@ public class ReviewService {
 				}
 			}
 		}
+
+		// 본인 리뷰 먼저 정렬
+		for (String purpose : reviewMap.keySet()) {
+			List<Map<String, Object>> reviews = reviewMap.get(purpose);
+			reviews.sort((r1, r2) -> {
+				boolean isAuthor1 = r1.get("author").equals(memberOptional.map(Member::getNickname).orElse(""));
+				boolean isAuthor2 = r2.get("author").equals(memberOptional.map(Member::getNickname).orElse(""));
+				return Boolean.compare(isAuthor2, isAuthor1);
+			});
+		}
+
 		response.put("purposeEval", purposePercentages);
 		response.put("reviewCount", spaceReviews.size());
 		response.put("reviews", reviewMap);


### PR DESCRIPTION
# Summary
공간별 공간기록 조회 API 응답에 유저 본인의 응답이 먼저 정렬되도록 수정

## To-do
- [x] 공간별 공간기록 조회 API

## Related Issues
- Resolves #296
