### PR TITLE
Hotfix: 멤버별 공간기록 조회 API 다중 이미지 처리 추가

### DIFF
--- a/localmood-api/src/main/java/com/localmood/api/review/service/ReviewService.java
+++ b/localmood-api/src/main/java/com/localmood/api/review/service/ReviewService.java
@@ -84,7 +84,7 @@ public class ReviewService {
 
 		return new ReviewResponseDto(
 			review.getSpace().getId(),
-			getReviewImageUrl(review.getId()),
+			image,
 			review.getSpace().getName(),
 			review.getSpace().getType().toString(),
 			review.getSpace().getAddress(),
@@ -105,9 +105,7 @@ public class ReviewService {
 	}
 
 	private String getReviewImageUrl(Long reviewId) {
-		return reviewImgRepository.findByReviewId(reviewId)
-			.map(ReviewImg::getImgUrl)
-			.orElse(null);
+		return getReviewImageUrls(reviewId).stream().findFirst().orElse(null);
 	}
 
 	private List<String> getReviewImageUrls(Long reviewId) {


### PR DESCRIPTION
# Summary
멤버별 공간기록 조회 API에서 다중 리뷰 이미지 조회 시 발생하는 오류 수정

## To-do
- [x] 멤버별 공간기록 조회 API 

## Related Issues
- Resolves #298 
