### PR TITLE
Refactor: 공간 관련 정보 조회 API 통합

### DIFF
--- a/localmood-api/src/main/java/com/localmood/api/space/controller/SpaceController.java
+++ b/localmood-api/src/main/java/com/localmood/api/space/controller/SpaceController.java
@@ -70,12 +70,12 @@ public class SpaceController {
 		return SuccessResponse.ok(res);
 	}
 
-	@GetMapping("/{spaceId}/curation")
-	public ResponseEntity<HashMap<String, Object>> getSpaceCuration(
+	@GetMapping("/{spaceId}/related-info")
+	public ResponseEntity<HashMap<String, Object>> getSpaceRelatedInfo(
 			@PathVariable(value = "spaceId") Long spaceId,
 			@CurrentUser Member member
 	){
-		var res = spaceService.getSpaceCuration(spaceId, Optional.ofNullable(member));
+		var res = spaceService.getSpaceRelatedInfo(spaceId, Optional.ofNullable(member));
 		return SuccessResponse.ok(res);
 	}
 

--- a/localmood-domain/src/main/java/com/localmood/domain/space/service/SpaceService.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/space/service/SpaceService.java
@@ -154,15 +154,15 @@ public class SpaceService {
 						.build()
 		);
 
-		// 공간과 비슷한 장소
-		spaceDetailMap.put("similarSpaceList", spaceRepository.findSimilarSpace(spaceInfo.getPurpose(), spaceInfo.getMood(), member));
-
 		return spaceDetailMap;
 	}
 
-	public HashMap<String,Object> getSpaceCuration(Long spaceId, Optional<Member> member) {
+	public HashMap<String,Object> getSpaceRelatedInfo(Long spaceId, Optional<Member> member) {
 		HashMap<String, Object> spaceCurationlMap = new HashMap<>();
 
+		SpaceInfo spaceInfo = spaceInfoRepository.findBySpaceId(spaceId).orElseThrow();
+
+		spaceCurationlMap.put("similarSpaceList", spaceRepository.findSimilarSpace(spaceInfo.getPurpose(), spaceInfo.getMood(), member));
 		spaceCurationlMap.put("relatedCurationList", curationRepository.findCurationBySpaceId(spaceId, member));
 
 		return spaceCurationlMap;


### PR DESCRIPTION
# Summary
AS-IS: 기존의 공간 상세 API 내에 **공간과 비슷한 장소 조회 (similarSpaceList)** 포함
TO-BE: 공간 상세 API에서 해당 기능 삭제 & **getSpaceRelatedInfo 로 통합** 

## To-do
- [x] getSpaceRelatedInfo 리팩토링

## Related Issues
- Resolves #300
