### PR TITLE
Feat: 카카오 회원 닉네임 변경 API

### DIFF
--- a/localmood-api/src/main/java/com/localmood/api/auth/controller/KakaoController.java
+++ b/localmood-api/src/main/java/com/localmood/api/auth/controller/KakaoController.java
@@ -1,11 +1,14 @@
 package com.localmood.api.auth.controller;
 
+import com.localmood.api.auth.CurrentUser;
 import com.localmood.api.auth.dto.LoginRequestDto;
 import com.localmood.api.auth.dto.oauth2.token.KakaoTokenJsonData;
 import com.localmood.api.auth.dto.oauth2.token.KakaoTokenResponse;
 import com.localmood.api.auth.dto.oauth2.user.KakaoUserInfoDto;
+import com.localmood.common.exception.ErrorCode;
 import com.localmood.api.auth.jwt.entity.TokenDto;
 import com.localmood.api.auth.service.AuthService;
+import com.localmood.domain.member.entity.Member;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -69,4 +72,22 @@ public class KakaoController {
                 .ok()
                 .body(tokenDto);
     }
+
+    @Description("사용자 닉네임을 변경합니다.")
+    @PutMapping("/nickname")
+    @ResponseBody
+    public ResponseEntity<?> updateNickname(
+            @CurrentUser Member member,
+            @RequestParam("newNickname") String newNickname) {
+        try {
+            authService.updateNickname(member.getEmail(), newNickname);
+            return ResponseEntity
+                    .ok()
+                    .body("닉네임이 성공적으로 업데이트되었습니다.");
+        } catch (Exception e) {
+            log.error("닉네임 업데이트 실패: {}", e.getMessage());
+            return ResponseEntity.status(ErrorCode.NICKNAME_UPDATE_FAILED.getHttpStatus())
+                    .body(ErrorCode.NICKNAME_UPDATE_FAILED.getMessage() + ": " + ErrorCode.NICKNAME_UPDATE_FAILED.getSolution());
+        }
+        }
 }

--- a/localmood-api/src/main/java/com/localmood/api/auth/service/AuthService.java
+++ b/localmood-api/src/main/java/com/localmood/api/auth/service/AuthService.java
@@ -286,4 +286,21 @@ public class AuthService {
 
     public boolean findUserByEmail(String email) { return memberRepository.existsByEmail(email);}
 
+    // 닉네임 변경
+    @Transactional
+    public void updateNickname(String email, String newNickname) {
+        Optional<Member> userOptional = memberRepository.findByEmail(email);
+        log.info("email: {}", email);
+        log.info("new nickname: {}", newNickname);
+
+        // 회원이 존재하는지 확인
+        if (userOptional.isPresent()) {
+            Member member = userOptional.get();
+            member.updateNickname(newNickname);
+            memberRepository.save(member);
+        } else {
+            throw new LocalmoodException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
+
 }

--- a/localmood-core/src/main/java/com/localmood/common/exception/ErrorCode.java
+++ b/localmood-core/src/main/java/com/localmood/common/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 	INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 형식입니다.", "올바른 이메일 주소를 입력하세요."),
 	INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호 형식입니다.", "비밀번호는 8~16자리여야 하며, 영문, 숫자, 특수문자를 포함해야 합니다."),
 	ALREADY_SCRAP_SPACE(HttpStatus.BAD_REQUEST, "이미 스크랩된 공간입니다.", "중복 스크랩은 불가합니다."),
-	ALREADY_SCRAP_CURATION(HttpStatus.BAD_REQUEST, "이미 스크랩된 큐레이션입니다.", "중복 스크랩은 불가합니다.");
+	ALREADY_SCRAP_CURATION(HttpStatus.BAD_REQUEST, "이미 스크랩된 큐레이션입니다.", "중복 스크랩은 불가합니다."),
+	NICKNAME_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "닉네임 업데이트에 실패했습니다.", "닉네임 업데이트를 다시 시도해주세요.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/localmood-domain/src/main/java/com/localmood/domain/member/entity/Member.java
+++ b/localmood-domain/src/main/java/com/localmood/domain/member/entity/Member.java
@@ -47,6 +47,11 @@ public class Member extends BaseTimeEntity {
 		return this;
 	}
 
+	public Member updateNickname(String newNickname) {
+		this.nickname = newNickname;
+		return this;
+	}
+
 	@Builder
 	public Member (String nickname, String email, String password, String profileImgUrl, Role role) {
 		this.nickname = nickname;


### PR DESCRIPTION
# Summary
카카오 소셜 회원가입 닉네임 변경 API

## To-do
- [x] 카카오 소셜 회원가입 닉네임 변경 API

## Related Issues
- Resolves #306 
